### PR TITLE
Add analytics tracking for user actions

### DIFF
--- a/app/components/FlowDiagram.tsx
+++ b/app/components/FlowDiagram.tsx
@@ -145,7 +145,7 @@ export default function FlowDiagram({
 
       setNodes(layoutedNodes)
       setEdges(layoutedEdges)
-      track('node_expand', { id: nodeId })
+      track('node_expand', { title: nodeToExpand.data.label })
 
       // Update history if we have a current history ID
       if (currentHistoryId) {
@@ -153,7 +153,9 @@ export default function FlowDiagram({
       }
     } catch (error) {
       console.error('Error expanding node:', error)
-      track('node_expand_error')
+      track('node_expand_error', {
+        message: error instanceof Error ? error.message : String(error),
+      })
     } finally {
       setExpandingNodeId(null)
     }

--- a/app/components/FlowDiagram.tsx
+++ b/app/components/FlowDiagram.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useState, useEffect } from 'react'
+import { track } from '@vercel/analytics'
 import ReactFlow, {
   Node,
   Edge,
@@ -144,6 +145,7 @@ export default function FlowDiagram({
 
       setNodes(layoutedNodes)
       setEdges(layoutedEdges)
+      track('node_expand', { id: nodeId })
 
       // Update history if we have a current history ID
       if (currentHistoryId) {
@@ -151,6 +153,7 @@ export default function FlowDiagram({
       }
     } catch (error) {
       console.error('Error expanding node:', error)
+      track('node_expand_error')
     } finally {
       setExpandingNodeId(null)
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,7 @@ export default function Home() {
     setSelectedFile(file)
     setTitle(file.name)
     setError("")
-    track('file_selected', { name: file.name, size: file.size })
+    track('synthesis_new_file', { name: file.name, size: file.size })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,7 +60,7 @@ export default function Home() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    track('synthesize_submit', { withFile: Boolean(selectedFile) })
+    track('synthesis_new_text', { query: title })
     setIsLoading(true)
     setError("")
     setDiagramData(null)
@@ -117,7 +117,7 @@ export default function Home() {
 
   const handleHistorySelect = (item: typeof history[0]) => {
     reloadHistory(); // Reload history from localStorage
-    track('history_select', { id: item.id })
+    track('history_select', { title: item.title })
     setTitle(item.title)
     setDiagramData({
       nodes: item.nodes,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react"
 import { useState, useRef } from "react"
+import { track } from "@vercel/analytics"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import {
@@ -54,10 +55,12 @@ export default function Home() {
     setSelectedFile(file)
     setTitle(file.name)
     setError("")
+    track('file_selected', { name: file.name, size: file.size })
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    track('synthesize_submit', { withFile: Boolean(selectedFile) })
     setIsLoading(true)
     setError("")
     setDiagramData(null)
@@ -67,6 +70,7 @@ export default function Home() {
       const newHistoryId = crypto.randomUUID()
       setDiagramData({ ...exampleData, historyId: newHistoryId })
       addToHistory("Example", exampleData.nodes, exampleData.edges)
+      track('synthesize_example')
       setIsLoading(false)
       return
     }
@@ -102,8 +106,10 @@ export default function Home() {
       const newHistoryId = crypto.randomUUID()
       setDiagramData({ ...data, historyId: newHistoryId })
       addToHistory(title, data.nodes, data.edges)
+      track('synthesize_success')
     } catch (error) {
       setError(error instanceof Error ? error.message : "An unknown error occurred")
+      track('synthesize_error', { message: error instanceof Error ? error.message : String(error) })
     } finally {
       setIsLoading(false)
     }
@@ -111,6 +117,7 @@ export default function Home() {
 
   const handleHistorySelect = (item: typeof history[0]) => {
     reloadHistory(); // Reload history from localStorage
+    track('history_select', { id: item.id })
     setTitle(item.title)
     setDiagramData({
       nodes: item.nodes,


### PR DESCRIPTION
## Summary
- instrument file upload and content synthesis actions with `track`
- track history selection and node expansion events

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685fe84c76d8832abcc3827ab817935c