### PR TITLE
Upgrade synthesis model to gpt-5.4

### DIFF
--- a/app/api/expand/route.ts
+++ b/app/api/expand/route.ts
@@ -32,7 +32,7 @@ Current diagram context:
 ${JSON.stringify({ nodes: currentNodes, edges: currentEdges }, null, 2)}`
 
     const response = await generateObject({
-      model: openai("o3"),
+      model: openai("gpt-5.4"),
       system: systemPrompt,
       prompt: prompt,
       schema: synthesisSchema

--- a/app/api/synthesize/route.ts
+++ b/app/api/synthesize/route.ts
@@ -25,7 +25,7 @@ export async function POST(req: Request) {
     if (file) {
       const fileBuffer = await file.arrayBuffer()
       response = await generateObject({
-        model: openai("o3"),
+        model: openai("gpt-5.4"),
         system: systemPrompt,
         messages: [
           {
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
       })
     } else {
       response = await generateObject({
-        model: openai("o3"),
+        model: openai("gpt-5.4"),
         system: systemPrompt,
         prompt: title,
         schema: synthesisSchema,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- switch synthesis endpoint to use `gpt-5.4`
- switch node expansion endpoint to use `gpt-5.4`
- keep all existing synthesis logic and schema unchanged

## Why this path
- `gpt-5.4-mini` had better speed, but output quality was not sufficient for your use case
- this PR is the selected upgrade path for final merge

## Changed files
- `app/api/synthesize/route.ts`
- `app/api/expand/route.ts`

## Notes
- quality/latency comparison branch `upgrade/gpt-5.4-mini` has been superseded
- this PR is ready for your merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-180302a6-8b23-47ac-807b-fd7b358a5504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-180302a6-8b23-47ac-807b-fd7b358a5504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

